### PR TITLE
Add ADS-B feeder plugin

### DIFF
--- a/src/takserver-adsb-cot-feeder/README.md
+++ b/src/takserver-adsb-cot-feeder/README.md
@@ -1,0 +1,34 @@
+# ADSB to CoT Feeder Plugin
+
+This plugin demonstrates how to feed TAK Server data channels with Cursor-on-Target (CoT) messages generated from ADS-B tracks. ADSB tracks may be obtained from a local SDR receiver or via the [adsb.lol](https://adsb.lol) API and converted to CoT using [adsbcot](https://github.com/snstac/adsbcot).
+
+The plugin expects a running `adsbcot` instance that outputs CoT messages over a TCP socket. Optionally, the plugin can launch `adsbcot` itself using the configured command.
+
+## Configuration
+Edit `tak.server.plugins.AdsbToCotFeederPlugin.yaml`:
+
+```yaml
+adsbSource: "adsb.lol"       # "local" for an SDR or "adsb.lol" for remote data
+feedUuid: "adsb-cot-feed"    # Data feed UUID
+adsbCotHost: "localhost"     # Host where adsbcot publishes CoT
+adsbCotPort: 5000            # Port used by adsbcot
+adsbCotCommand: ""           # Optional command to launch adsbcot
+system: {archive: true}
+```
+
+## Build
+From this directory (`src/takserver-adsb-cot-feeder`):
+
+```bash
+./gradlew clean shadowJar
+```
+
+The resulting JAR is written to `build/libs/`.
+
+## Install into TAK Server
+1. Create a `lib` directory under your TAK Server execution directory and copy the generated JAR there.
+2. Create a `conf/plugins` directory under the execution directory.
+3. Copy `tak.server.plugins.AdsbToCotFeederPlugin.yaml` into the `conf/plugins` directory and edit as needed.
+4. Start the TAK Server Messaging, API, and Plugin processes ensuring that the `lib` directory is on the plugin classpath.
+
+Once started, the plugin creates the configured data feed (if needed), connects to the `adsbcot` socket, converts received CoT XML into protobuf messages, and publishes them to the selected feed.

--- a/src/takserver-adsb-cot-feeder/build.gradle
+++ b/src/takserver-adsb-cot-feeder/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'java-library'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
+repositories {
+  flatDir {
+    dirs '../../takserver-plugins/build/libs'
+  }
+
+/**
+ * -- Uncomment this if pulling takserver-plugins.jar from artifactory instead of using local build version --
+  maven {
+    url = 'https://artifacts.tak.gov/artifactory/maven'
+    credentials {
+      username = "$takGovUser"
+      password = "$takGovPassword"
+    }
+  }
+ */
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
+buildscript {
+  repositories {
+    mavenCentral()
+    maven {
+      url 'https://plugins.gradle.org/m2'
+    }
+  }
+  dependencies {
+    classpath 'gradle.plugin.com.github.johnrengelman:shadow:' + gradle_shadow_version
+  }
+}
+
+dependencies {
+  // Use the local takserver-plugins-<version>.jar
+  implementation group: '', name: 'takserver-plugins', version: '+', classifier: 'all'
+
+  /*
+    Use this line instead if pulling from and testing a different tak-server version than the local one ---
+    implementation group: 'gov.tak', name: 'takserver-plugins', version: takserver_plugins_version, classifier: 'all'
+ */
+
+  // add additional depenencies as required for your TAK Server plugin
+}
+
+

--- a/src/takserver-adsb-cot-feeder/gradle.properties
+++ b/src/takserver-adsb-cot-feeder/gradle.properties
@@ -1,0 +1,27 @@
+# Increasing heap size since it is failing on the CI
+org.gradle.jvmargs=-Xmx768m
+
+commons_codec_version = 1.11
+commons_lang_version = 3.12.0
+
+dom4j_version = 2.1.3
+
+httpcomponents_version = 4.5.13
+slf4j_version = 1.7.32
+logback_version = 1.2.11
+log4j_api_version = 2.17.1
+postgres_version = 42.3.3
+
+spring_version = 5.3.21
+spring_security_version = 5.7.5
+spring_security_jwt_version = 1.1.1.RELEASE
+spring_boot_version = 2.7.1
+spring_cloud_starter_version = 2.4.1
+spring_data_commons_version = 2.7.1
+spring_data_version = 2.7.1
+
+guava_version = 30.1-jre
+intellij_annotations_version = 12.0
+
+gradle_shadow_version = 7.1.2
+takserver_plugins_version = 4.8-release-36

--- a/src/takserver-adsb-cot-feeder/settings.gradle
+++ b/src/takserver-adsb-cot-feeder/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'takserver-adsb-cot-feeder'

--- a/src/takserver-adsb-cot-feeder/src/main/java/tak/server/plugins/AdsbToCotFeederPlugin.java
+++ b/src/takserver-adsb-cot-feeder/src/main/java/tak/server/plugins/AdsbToCotFeederPlugin.java
@@ -1,0 +1,146 @@
+package tak.server.plugins;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import atakmap.commoncommo.protobuf.v1.MessageOuterClass.Message;
+
+import com.bbn.takserver.plugin.annotation.TakServerPlugin;
+import com.bbn.takserver.plugin.messages.MessageSenderBase;
+import tak.server.plugins.PluginDataFeedApi;
+
+/**
+ * Plugin that converts ADS-B tracks to Cursor-on-Target messages using the
+ * adsbcot project. It connects to a running adsbcot instance that outputs CoT
+ * messages over a TCP socket and forwards those messages to a TAK Server data
+ * feed.
+ */
+@TakServerPlugin(
+    name = "ADSB to CoT Feeder",
+    description = "Feeds CoT tracks generated from ADS-B data"
+)
+public class AdsbToCotFeederPlugin extends MessageSenderBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(AdsbToCotFeederPlugin.class);
+
+    /**
+     * ADSB source. Can be "local" for SDR input or "adsb.lol" for the API.
+     */
+    private String adsbSource = "adsb.lol";
+
+    /** UUID of the data feed to publish CoT messages to. */
+    private String feedUuid = "adsb-cot-feed";
+
+    /** Host running the adsbcot service. */
+    private String adsbCotHost = "localhost";
+
+    /** Port where adsbcot publishes CoT messages. */
+    private int adsbCotPort = 5000;
+
+    /** Optional command to launch adsbcot if not already running. */
+    private String adsbCotCommand = "";
+
+    private ExecutorService receiver;
+    private volatile boolean running;
+    private Process adsbCotProcess;
+    private Socket socket;
+
+    public AdsbToCotFeederPlugin() {
+        if (config.containsProperty("adsbSource")) {
+            adsbSource = config.getProperty("adsbSource").toString();
+        }
+        if (config.containsProperty("feedUuid")) {
+            feedUuid = config.getProperty("feedUuid").toString();
+        }
+        if (config.containsProperty("adsbCotHost")) {
+            adsbCotHost = config.getProperty("adsbCotHost").toString();
+        }
+        if (config.containsProperty("adsbCotPort")) {
+            adsbCotPort = (int) config.getProperty("adsbCotPort");
+        }
+        if (config.containsProperty("adsbCotCommand")) {
+            adsbCotCommand = config.getProperty("adsbCotCommand").toString();
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+        logger.info("ADSB to CoT Feeder starting. source={}, feed={}", adsbSource, feedUuid);
+
+        List<String> tags = new ArrayList<>();
+        tags.add("adsb");
+        try {
+            PluginDataFeedApi api = getPluginDataFeedApi();
+            api.create(feedUuid, "adsb-feed", tags);
+        } catch (Exception e) {
+            logger.debug("Data feed {} may already exist: {}", feedUuid, e.getMessage());
+        }
+
+        if (!adsbCotCommand.isEmpty()) {
+            logger.info("Launching adsbcot: {}", adsbCotCommand);
+            adsbCotProcess = new ProcessBuilder(adsbCotCommand.split(" ")).start();
+        }
+
+        receiver = Executors.newSingleThreadExecutor();
+        running = true;
+        receiver.submit(this::receiveLoop);
+    }
+
+    private void receiveLoop() {
+        try {
+            socket = new Socket(adsbCotHost, adsbCotPort);
+            InputStream is = socket.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            String line;
+            while (running && (line = reader.readLine()) != null) {
+                try {
+                    Message m = getConverter().cotStringToDataMessage(line, null, "adsb");
+                    send(m, feedUuid);
+                } catch (Exception e) {
+                    logger.warn("Failed to process CoT message", e);
+                }
+            }
+        } catch (IOException e) {
+            if (running) {
+                logger.error("Error reading from adsbcot", e);
+            }
+        }
+    }
+
+    @Override
+    public void stop() throws Exception {
+        running = false;
+        if (receiver != null) {
+            receiver.shutdownNow();
+        }
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        if (adsbCotProcess != null) {
+            adsbCotProcess.destroy();
+        }
+        logger.info("ADSB to CoT Feeder stopped.");
+    }
+
+    public void setAdsbSource(String adsbSource) {
+        this.adsbSource = adsbSource;
+    }
+
+    public void setFeedUuid(String feedUuid) {
+        this.feedUuid = feedUuid;
+    }
+}

--- a/src/takserver-adsb-cot-feeder/tak.server.plugins.AdsbToCotFeederPlugin.yaml
+++ b/src/takserver-adsb-cot-feeder/tak.server.plugins.AdsbToCotFeederPlugin.yaml
@@ -1,0 +1,6 @@
+adsbSource: "adsb.lol"
+feedUuid: "adsb-cot-feed"
+adsbCotHost: "localhost"
+adsbCotPort: 5000
+adsbCotCommand: ""
+system: {archive: true}


### PR DESCRIPTION
## Summary
- implement ADS-B CoT feeder plugin using adsbcot socket
- add configuration options in README and sample YAML

## Testing
- `../gradlew clean shadowJar` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684de86724ac8333a7eefb13b339dce8